### PR TITLE
Fixed the bug without "re" module

### DIFF
--- a/openvas_lib/__init__.py
+++ b/openvas_lib/__init__.py
@@ -24,6 +24,7 @@ from openvas_lib.data import *
 from openvas_lib.utils import *
 from openvas_lib.common import *
 
+import re
 __license__ = """
 OpenVAS connector for OMP protocol.
 


### PR DESCRIPTION
Function of report_parser need to re.compiler but it did not import it.