### PR TITLE
Add create target option for "Alive Test"

### DIFF
--- a/openvas_lib/__init__.py
+++ b/openvas_lib/__init__.py
@@ -569,6 +569,7 @@ class VulnscanManager(object):
 					profile = "empty",
 					callback_end = partial(lambda x: x.release(), sem),
 					callback_progress = my_print_status
+					alive_test = "TCP-ACK Service Ping"
 				)
 
 				# Wait
@@ -615,6 +616,9 @@ class VulnscanManager(object):
 								  with the progress percentaje as a float.
 		:type callback_progress: function(float)
 
+		:param alive_test: Alive Test to check if a target is reachable
+		:type alive_test: str
+
 		:return: ID of the audit and ID of the target: (ID_scan, ID_target)
 		:rtype: (str, str)
 		"""
@@ -648,6 +652,11 @@ class VulnscanManager(object):
 		except TypeError:
 			max_checks = None
 
+		try:
+			alive_test = str(kwargs.get("alive_test", "Scan Config Default"))
+		except TypeError:
+			alive_test = None
+
 		comment = str(kwargs.get("comment", 'New scan launched on target hosts: %s' % ",".join(target)))
 
 		port_list_name = kwargs.get("port_list", "openvas default")
@@ -661,7 +670,7 @@ class VulnscanManager(object):
 		# Create the target
 		try:
 			m_target_id = self.__manager.create_target(m_target_name, target,
-													   "Temporal target from OpenVAS Lib", port_list_id)
+													   "Temporal target from OpenVAS Lib", port_list_id, alive_test)
 		except ServerError as e:
 			raise VulnscanTargetError("The target already exits on the server. Error: %s" % e.message)
 

--- a/openvas_lib/common.py
+++ b/openvas_lib/common.py
@@ -635,6 +635,9 @@ class OMP(object):
 		:param comment: comment to add to task
 		:type comment: str
 
+		:param alive_test: Alive Test to check if a target is reachable
+		:type alive_test: str
+
 		:return: the ID of the created target.
 		:rtype: str
 

--- a/openvas_lib/ompv7.py
+++ b/openvas_lib/ompv7.py
@@ -547,7 +547,7 @@ class OMPv7(OMP):
 	#
 	# ----------------------------------------------------------------------
 
-	def create_target(self, name, hosts, comment="", port_list=""):
+	def create_target(self, name, hosts, comment="", port_list="", alive_test=""):
 		"""
 		Creates a target in OpenVAS.
 
@@ -562,6 +562,9 @@ class OMPv7(OMP):
 
 		:param port_list: Port List ID to use for the target
 		:type port_list: str
+
+		:param alive_test: Alive Test to check if a target is reachable
+		:type alive_test: str
 
 		:return: the ID of the created target.
 		:rtype: str
@@ -581,6 +584,9 @@ class OMPv7(OMP):
 		request = """<create_target>
 				<name>%s</name>
 				<hosts>%s</hosts>""" % (name, m_targets)
+
+		if alive_test:
+			request += """<alive_tests>%s</alive_tests>"""%alive_test
 
 		if port_list:
 			request += """<port_list id="%s"/>"""%port_list


### PR DESCRIPTION
I want to change "alive test" settings.

http://www.openvas.org/omp-6-0.html#type_alive_test

This Pull Request add the option for Alive Test in create_target_method.
openvas_lib user will be able to choice other alive test methods. 
