### PR TITLE
Create_task() Schedule parameter bug. Parameter was not passing corre…

### DIFF
--- a/openvas_lib/ompv7.py
+++ b/openvas_lib/ompv7.py
@@ -706,8 +706,7 @@ class OMPv7(OMP):
 			<target id="%s"/>""" % (name, comment, config, target)
 
 		if schedule:
-			request += """<schedule>%s</schedule>""" % (schedule)
-
+			request += """<schedule id= "%s"/>""" % (schedule)
 
 		if max_checks or max_hosts:
 			request += """<preferences>"""


### PR DESCRIPTION
As indicated on issues #41  and #43 the schedule ID was not passed in the XML. 